### PR TITLE
RSS -> ATOM

### DIFF
--- a/postprocessing.py
+++ b/postprocessing.py
@@ -49,4 +49,4 @@ with open('subscriptions.csv') as f:
 
         fg.updated(updated)
 
-        fg.rss_file('rss/' + user + '.xml', pretty=True) # Write the RSS feed to a file
+        fg.atom_file('rss/' + user + '.xml', pretty=True) # Write the RSS feed to a file


### PR DESCRIPTION
It's a newer, more robust format :)

AFAIK all major RSS readers support it just fine (tested with Feedly, it didn't even blink).

An alternative would be to write both, but I'm not sure of a reason to _need_ RSS...